### PR TITLE
updates package.js to be compatible with atmospherejs

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'flot:flot',
   version: '0.8.3',
   summary: 'A meteor package for jQuery flot.',
-  git: 'https://github.com/dotansimha/flot.git',
+  git: "https://github.com/dotansimha/flot",
   documentation: null
 });
 


### PR DESCRIPTION
There are two flot packages when you search on atmosphere. I have suggested to the other repo owner that his package be deprecated to this one because theirs is out of date by a few versions. 

In any event the atmostphere package manager is not able to display the readme.md from this repo due to the formatting in package.js